### PR TITLE
fix: enforce using only existing repository labels

### DIFF
--- a/.github/actions/strands-task-labeller/action.yml
+++ b/.github/actions/strands-task-labeller/action.yml
@@ -108,10 +108,10 @@ runs:
 
 ## Process
 1. First, search for similar issues using search_similar_issues tool to understand context
-2. Get available repository labels using GitHub API
+2. Get available repository labels using list_repository_labels tool
 3. Read the automation configuration from .github/config/automation-config.json for area experts
 4. Analyze the issue title, description, and any provided context
-5. Apply appropriate labels using GitHub tools
+5. Apply ONLY existing labels from step 2 using add_labels_to_issue tool
 6. Tag relevant area experts with @mentions in a comment
 
 ## Similar Issues Analysis
@@ -121,8 +121,10 @@ runs:
 - Reference similar issues in your summary if relevant
 
 ## Label Assignment
-- Use list_issues or GitHub API to get available repository labels dynamically
-- Apply labels that match the issue content (bug, enhancement, documentation, etc.)
+- CRITICAL: Use list_repository_labels tool FIRST to get available labels
+- ONLY apply labels that exist in the repository - NEVER create new labels
+- Match issue content to existing labels (bug, enhancement, documentation, etc.)
+- If no perfect match exists, choose the closest existing label
 - Focus on categorization labels that help with organization
 
 ## Area Expert Assignment Rules

--- a/.github/scripts/python/agent_runner.py
+++ b/.github/scripts/python/agent_runner.py
@@ -29,6 +29,7 @@ from github_tools import (
     get_pr_review_and_comments,
     list_issues,
     list_pull_requests,
+    list_repository_labels,
     reply_to_review_comment,
     search_similar_issues,
     update_issue,
@@ -67,6 +68,7 @@ def _get_all_tools() -> list[Any]:
         add_labels_to_issue,
         get_issue_comments,
         search_similar_issues,
+        list_repository_labels,
         
         # GitHub PR tools
         create_pull_request,

--- a/.github/scripts/python/github_tools.py
+++ b/.github/scripts/python/github_tools.py
@@ -930,4 +930,33 @@ def search_similar_issues(query: str, state: str = "all", limit: int = 5, repo: 
         return error_msg
 
 
+@tool
+@log_inputs
+def list_repository_labels(repo: str | None = None) -> str:
+    """Lists all available labels in the repository.
+
+    Args:
+        repo: GitHub repository in the format "owner/repo" (optional; falls back to env var)
+
+    Returns:
+        List of available label names
+    """
+    result = _github_request("GET", "labels", repo)
+    if isinstance(result, str):
+        console.print(Panel(escape(result), title="[bold red]Error", border_style="red"))
+        return result
+
+    if not result:
+        message = f"No labels found in {repo or os.environ.get('GITHUB_REPOSITORY')}"
+        console.print(Panel(escape(message), title="[bold yellow]Info", border_style="yellow"))
+        return message
+
+    label_names = [label["name"] for label in result]
+    output = f"Available labels in {repo or os.environ.get('GITHUB_REPOSITORY')}:\n"
+    output += ", ".join(label_names)
+
+    console.print(Panel(escape(output), title="[bold green]🏷️ Repository Labels", border_style="blue"))
+    return output
+
+
 


### PR DESCRIPTION
- Add list_repository_labels tool to fetch available labels
- Update system prompt to require fetching labels first
- Enforce NEVER creating new labels, only using existing ones
- Import new tool in agent_runner.py

This prevents the agent from creating non-existent labels.

## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run check`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
